### PR TITLE
Improve efficiency of getRendition

### DIFF
--- a/src/main/java/com/avionos/aem/assets/cacheablerenditions/servlets/CacheableRenditionServlet.java
+++ b/src/main/java/com/avionos/aem/assets/cacheablerenditions/servlets/CacheableRenditionServlet.java
@@ -76,7 +76,7 @@ public final class CacheableRenditionServlet extends SlingSafeMethodsServlet {
     }
 
     private Rendition getRendition(final Asset asset, final String renditionName) {
-        return getRenditionForName(asset, renditionName).orElse(getRenditionForBaseName(asset, renditionName));
+        return getRenditionForName(asset, renditionName).orElseGet(() -> getRenditionForBaseName(asset, renditionName));
     }
 
     private Rendition getRenditionForBaseName(final Asset asset, final String renditionName) {


### PR DESCRIPTION
If you find the rendition by the requested name, there is no reason to try to find it by the basename also. But, `orElse()` on an
Optional will evaluate its parameter every time. Switching to `orElseGet` and a Suppler lambda expression prevents that.